### PR TITLE
Allow only one matching making session from a user

### DIFF
--- a/frontend/src/components/modal/MatchingModal.tsx
+++ b/frontend/src/components/modal/MatchingModal.tsx
@@ -87,8 +87,14 @@ function MatchingModal({
 
     socketRef.current.on('disconnect', () => {
       console.log('Disconnected from WebSocket server');
+      notifications.show({
+        title: 'Seach cancelled',
+        message: 'There is already an existing matching session. Please try again later.',
+        color: 'red',
+      });
+      handleCancel();
     });
-  }, [difficulty, topics, matchFound, isConnecting, navigate]);
+  }, [difficulty, topics, matchFound, isConnecting, navigate, closeMatchingModal]);
 
   useEffect(() => {
     if (isMatchingModalOpened) {

--- a/frontend/src/components/modal/MatchingModal.tsx
+++ b/frontend/src/components/modal/MatchingModal.tsx
@@ -87,11 +87,15 @@ function MatchingModal({
 
     socketRef.current.on('disconnect', () => {
       console.log('Disconnected from WebSocket server');
+    });
+
+    socketRef.current.on('existing_search', () => {
       notifications.show({
-        title: 'Seach cancelled',
+        title: 'Existing search',
         message: 'There is already an existing matching session. Please try again later.',
         color: 'red',
       });
+      socketRef.current?.close();
       handleCancel();
     });
   }, [difficulty, topics, matchFound, isConnecting, navigate, closeMatchingModal]);

--- a/match-notification-service/server.js
+++ b/match-notification-service/server.js
@@ -74,7 +74,7 @@ io.on('connection', (socket) => {
   // Register the userId with the socket and send search request to RabbitMQ
   socket.on('register', (userId, difficulty, topics) => {
     if (connectedClients[userId]) {
-      socket.disconnect(true);  // Force disconnect the existing socket
+      io.to(socket.id).emit('existing_search', 'User is already searching in another matching service.');
       console.log(`User ${userId} is already searching in matching service.`);
     } else {
       // Register the new connection

--- a/match-notification-service/server.js
+++ b/match-notification-service/server.js
@@ -73,13 +73,19 @@ io.on('connection', (socket) => {
 
   // Register the userId with the socket and send search request to RabbitMQ
   socket.on('register', (userId, difficulty, topics) => {
-    connectedClients[userId] = socket.id;
-    console.log(`User ${userId} registered with socket ${socket.id}`);
+    if (connectedClients[userId]) {
+      socket.disconnect(true);  // Force disconnect the existing socket
+      console.log(`User ${userId} is already searching in matching service.`);
+    } else {
+      // Register the new connection
+      connectedClients[userId] = socket.id;
+      console.log(`User ${userId} registered with socket ${socket.id}`);
 
-    // Send search request to RabbitMQ
-    const searchRequest = { userId, difficulty, topics };
-    channel.sendToQueue('search_queue', Buffer.from(JSON.stringify(searchRequest)));
-    console.log(`Search request sent for user ${userId}`);
+      // Send search request to RabbitMQ
+      const searchRequest = { userId, difficulty, topics };
+      channel.sendToQueue('search_queue', Buffer.from(JSON.stringify(searchRequest)));
+      console.log(`Search request sent for user ${userId}`);
+    }
   });
 
   // Handle user disconnect


### PR DESCRIPTION
Resolves #35 

Previously users can log into multiple sessions and simultaneously enter the match-making.

Now only the first user session is allowed to be in the match making session.

Other user session will be met with an error as seen below when attempting to match-make.

![Screenshot 2024-10-21 at 1 48 02 AM](https://github.com/user-attachments/assets/8b9c12e2-67a9-4f5d-80bc-8354e1688a5b)
