### PR TITLE
Fix match notification nginx connection bug

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -106,8 +106,6 @@ services:
     build:
       context: ./match-notification-service
     container_name: match-notification-service
-    ports:
-      - "4001:4001"
     networks:
       - my-network
     depends_on:

--- a/frontend/src/components/modal/MatchingModal.tsx
+++ b/frontend/src/components/modal/MatchingModal.tsx
@@ -51,7 +51,8 @@ function MatchingModal({
 
     setIsConnecting(true);
 
-    socketRef.current = io('http://localhost:4001', {
+    socketRef.current = io('http://localhost', {
+      path: '/api/matching-notification/socket.io',
       transports: ['websocket'],
       reconnectionAttempts: 5,
       reconnectionDelay: 1000,

--- a/match-notification-service/server.js
+++ b/match-notification-service/server.js
@@ -22,6 +22,7 @@ const io = new Server(server, {
     origin: "*",  // Allow all origins
     methods: ['GET', 'POST'],
   },
+  path: '/api/matching-notification/socket.io',
   pingTimeout: 60000,  // Set a higher timeout (e.g., 60 seconds)
   pingInterval: 25000,  // Interval between ping packets
 });

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -35,11 +35,15 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
-  location ~ ^/api/(matching-notification) {
+  location ~ ^/api/matching-notification/socket.io {
     proxy_pass http://$MATCH_NOTIFICATION_SERVICE_ADDR;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 }
 


### PR DESCRIPTION
# Changes made

- Previously we had to expose port 4001 in docker to be able to connect to match-notification-service.
- It was an issue with routing on both the nginx side and notification service.